### PR TITLE
Adding jupyterlab-conda-store jupyerlab extension

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -56,3 +56,4 @@ dependencies:
   - pip:
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
+      - jupyterlab-conda-store


### PR DESCRIPTION
This PR adds the jupyterlab-conda-store extension for interacting with the conda-store server