### PR TITLE
Bump jupyterlab-conda-store to at least 0.2.4

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -56,4 +56,4 @@ dependencies:
   - pip:
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
-      - jupyterlab-conda-store
+      - jupyterlab-conda-store >=0.2.4


### PR DESCRIPTION
Bump jupyterlab-conda-store to at least 0.2.4 we get the latest to jupyterlab-conda-store 

![image](https://user-images.githubusercontent.com/1740337/215009602-8f89044b-241d-4bc3-b019-33a897ee77b2.png)

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [X] Other (please describe): version update
