### PR TITLE
Update jupyterlab-conda-store to latest version

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -55,7 +55,7 @@ dependencies:
   - pip:
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
-      - jupyterlab-conda-store==2023.9.1 
+      - jupyterlab-conda-store==2023.10.1 
       - jupyter-tensorboard
       - jupyterlab_nvdashboard
       - argo-jupyter-scheduler==2023.7.1


### PR DESCRIPTION
In #89, we updated to 2023.9.1, but the latest release is 2023.10.1 (which was missed because of a conda-store issue where a tag wasn't created during release - this is being investigated separately).

This PR pins the latest available version on PyPI 