### PR TITLE
Update argo-jupyter-scheduler to 2024.1.3

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -58,5 +58,5 @@ dependencies:
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
       - jhub-apps==2024.1.2
-      - argo-jupyter-scheduler==2023.7.1
+      - argo-jupyter-scheduler==2024.1.3
       - jupyter_ai


### PR DESCRIPTION
Updates the argo-jupyter-scheduler version to 2024.1.3, see [the release notes](
https://github.com/nebari-dev/argo-jupyter-scheduler/releases/tag/2024.1.3).

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): updates a dependency.

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

Tested on a Nebari cluster:

- "Run now" works and files are downloadable in the web UI (HTML and notebook)
- "Run on schedule" works and files are downloadable in the web UI (HTML and notebook)
- send to Slack works when using "Run now"
- send to Slack works when using "Run on schedule"
- status is set to "Failed" when an exception is raised in a notebook; the notebook is downloadable with an error message present via the web UI
- status is set to "Failed" when an invalid token is used when sending to Slack; the notebook and HTML output are downloadable via the web UI
- files are deleted from `.local/share/jupyter/scheduler_staging_area/` when deleted via the web UI
- information is printed to logs on disk, including error messages
- scheduled jobs continue to run even when the server is not running.

Images used:

```yaml
default_images:
  jupyterhub: quay.io/nebari/nebari-jupyterhub:2024.1.1rc2
  dask_worker: quay.io/nebari/nebari-dask-worker:2024.1.1rc2
  jupyterlab: docker.io/nkaretnikov/nebari-jupyterlab-ctest:79  # this PR
```

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
