### PR TITLE
Require jupyter-server-proxy 4.1.1

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   # jupyterhub/jupyterlab
   - nb_conda_kernels
   - ipython > 7
-  - jupyter-server-proxy
+  - jupyter-server-proxy >=4.1.1
   - "jupyter_server>=2.4.0"
   - jupyterlab >=4
   - jupyter_client


### PR DESCRIPTION
Updates to the latest jupyter-server-proxy version