### PR TITLE
Pin jupyter-scheduler to version 2.5.2 or newer

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,6 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
+  - jupyter-scheduler >=2.5.2
 
   # viz tools
   - param


### PR DESCRIPTION
## Reference Issues or PRs

Pins `jupyter-scheduler` to version 2.5.2 or newer.

So far `jupyter-scheduler` was installed as a dependency of `argo-jupyter-scheduler` without explicit versioning; this PR ensures we get the latest version.

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):
