### PR TITLE
Align JupyterHub version across images, pin to 4.1.5

### DIFF
--- a/jupyterhub/environment.yaml
+++ b/jupyterhub/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip==21.1.2
-  - jupyterhub==4.1.0
+  - jupyterhub==4.1.5
   - jupyterhub-kubespawner==4.2.0
   - oauthenticator==16.3.0
   - escapism==1.0.1

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
   - jupyterlab >=4
   - jupyter_client
   - jupyter_console
-  - jupyterhub==4.0.2
+  - jupyterhub==4.1.5
   - nbconvert
   - nbval
 


### PR DESCRIPTION
## Reference Issues or PRs

PR #129 updated jupyterhub in jupyter**hub** image to 4.1.0 (which included a security vulnerability fix).
However, the jupyterhub dependency is also included in the jupyter**lab** image, which I overlooked.

This PR aligns the versions, pinning to the latest 4.1.5 (the point releases fixed regressions identified in the fix for security vulnerability)

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?
