### PR TITLE
Pin `jupyter-scheduler` version to below 2.6.0

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -35,7 +35,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler >=2.5.2
+  - jupyter-scheduler >=2.5.2,<2.6.0
 
   # viz tools
   - param


### PR DESCRIPTION
## Reference Issues or PRs

Pin version to avoid https://github.com/jupyter-server/jupyter-scheduler/issues/519 as discussed in https://github.com/nebari-dev/argo-jupyter-scheduler/pull/10#issuecomment-2120841561

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?