### PR TITLE
Bump jhub-apps to `2024.6.1rc2`

### DIFF
--- a/jupyterhub/environment.yaml
+++ b/jupyterhub/environment.yaml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - nebari-jupyterhub-theme==2024.5.1
     - python-keycloak==0.26.1
-    - jhub-apps==2024.6.1rc1
+    - jhub-apps==2024.6.1rc2

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -60,7 +60,7 @@ dependencies:
       # vscode jupyterlab launcher
       - git+https://github.com/betatim/vscode-binder
       - argo-jupyter-scheduler==2024.6.1rc1
-      - jhub-apps==2024.6.1rc1
+      - jhub-apps==2024.6.1rc2
       - jupyterlab-nebari-mode==0.3.0
       - jupyterlab-conda-store==2024.3.1
       - jupyterlab-new-launcher==0.4.2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Bumped to latest release: https://pypi.org/project/jhub-apps/2024.6.1rc2/

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): Bump jhub-apps package version

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
