### PR TITLE
Pin `kubernetes_asyncio` to `29.0.0`

### DIFF
--- a/jupyterhub/environment.yaml
+++ b/jupyterhub/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - oauthenticator==16.3.0
   - escapism==1.0.1
   - python-kubernetes
-  - kubernetes_asyncio
+  - kubernetes_asyncio==29.0.0
   - jupyterhub-idle-culler==1.2.1
   - sqlalchemy==1.4.46
   - pip:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
A recent release in `kubernetes_asyncio` has broken JupyterHub and jhub-apps.

Fixes #163

https://github.com/nebari-dev/nebari-docker-images/pull/161 needs to get in first to make the CI work again.

```
│   File "/opt/conda/lib/python3.9/site-packages/kubernetes_asyncio/config/kube_config.py", line 38, in <module>                                                                                                                                                               │
│     KUBE_CONFIG_DEFAULT_LOCATION = os.environ.get('KUBECONFIG', (pathlib.Path.home() / '.kube/config').as_posix())                                                                                                                                                           │
│   File "/opt/conda/lib/python3.9/pathlib.py", line 1143, in home                                                                                                                                                                                                             │
│     return cls(cls()._flavour.gethomedir(None))                                                                                                                                                                                                                              │
│   File "/opt/conda/lib/python3.9/pathlib.py", line 390, in gethomedir                                                                                                                                                                                                        │
│     return pwd.getpwuid(os.getuid()).pw_dir                                                                                                                                                                                                                                  │
│ KeyError: 'getpwuid(): uid not found: 1000'                                         
```

It was released on [Jun 9, 2024](https://pypi.org/project/kubernetes-asyncio/30.1.0/#history)
Pull request in upstream, that potentially caused it: https://github.com/tomplus/kubernetes_asyncio/pull/307

I have verified the error is gone in the previous version.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
