### PR TITLE
Upgrade to JupyterHub 5.1.0

### DIFF
--- a/jupyterhub/environment.yaml
+++ b/jupyterhub/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip==21.1.2
-  - jupyterhub==5.0.0
+  - jupyterhub==5.1.0
   - jupyterhub-kubespawner==4.2.0
   - oauthenticator==16.3.0
   - escapism==1.0.1

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -16,7 +16,7 @@ dependencies:
   - jupyterlab >=4
   - jupyter_client
   - jupyter_console
-  - jupyterhub==5.0.0
+  - jupyterhub==5.1.0
   - nbconvert
   - nbval
 


### PR DESCRIPTION
## Reference Issues or PRs

- Prerequisite for https://github.com/nebari-dev/nebari/issues/2602.

Basically opening this PR to make it easier for the core team to upgrade to JupyterHub 5.1.0 (and send a gentle nudge) - this PR comes with the docker images required for testing the new version:

```yaml
default_images:
  jupyterhub: quay.io/nebari/nebari-jupyterhub:krassowski-jupyterhub-5.1
  jupyterlab: quay.io/nebari/nebari-jupyterlab:krassowski-jupyterhub-5.1
```

https://github.com/nebari-dev/nebari-docker-images/actions/runs/10614011049

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?