### PR TITLE
Add `jupyterlab-jhub-apps` extension to base image

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -66,3 +66,4 @@ dependencies:
       - jupyterlab-conda-store==2024.3.1
       - jupyterlab-launchpad==1.0.2
       - jupyterlab-gallery==0.6.3
+      - jupyterlab-jhub-apps==0.3.1


### PR DESCRIPTION
## Reference Issues or PRs

- Addresses https://github.com/nebari-dev/jhub-apps/issues/472
- Depends on https://github.com/nebari-dev/nebari-docker-images/pull/184
- https://github.com/nebari-dev/jupyterlab-jhub-apps
- This extension will be automatically disabled in nebari if `jhub-apps` is disabled in `nebari-config.yaml` once https://github.com/nebari-dev/nebari/pull/2804 is merged

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->