### PR TITLE
Adjust pin on jupyter scheduler

### DIFF
--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler
+  - jupyter-scheduler >=2.8  
 
   # viz tools
   - param

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler >=2.5.2,<2.6.0
+  - jupyter-scheduler
 
   # viz tools
   - param

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler >=2.8.0
+  - jupyter-scheduler >=2.8.0,<3.0.0
 
   # viz tools
   - param

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler >=2.8.0,<3.0.0
+  - jupyter-scheduler >=2.8.0,<3.0.0  # >=2.8 due to https://github.com/conda-forge/jupyter_scheduler-feedstock/issues/46
 
   # viz tools
   - param

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - jupyterlab-pioneer
   - jupyter-ai
   - jupyterlab-favorites >=3.2.1
-  - jupyter-scheduler >=2.8  
+  - jupyter-scheduler >=2.8.0
 
   # viz tools
   - param


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
Jupyter scheduler was originally pinned in https://github.com/nebari-dev/nebari-docker-images/pull/148 due to https://github.com/jupyter-server/jupyter-scheduler/issues/519.  The issue is resolved in v2.7.0 so I'm adjusting the pin.  A separate [packaging on conda forge issue](https://github.com/conda-forge/jupyter_scheduler-feedstock/issues/46) requires the pin be >= 2.8 for the time being.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Any other comments?